### PR TITLE
chore: rearrange dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,15 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "@netcracker/qubership-apihub-api-diff": "2.0.0",
+        "@netcracker/qubership-apihub-api-unifier": "2.0.0",
+        "@netcracker/qubership-apihub-graphapi": "1.0.8",
+        "@netcracker/qubership-apihub-json-crawl": "1.0.4"
+      },
       "devDependencies": {
+        "@netcracker/qubership-apihub-compatibility-suites": "2.0.3",
+        "@netcracker/qubership-apihub-jest-chrome-in-docker-environment": "2.0.0",
         "@netcracker/qubership-apihub-npm-gitflow": "3.0.1",
         "@typescript-eslint/eslint-plugin": "6.0.0",
         "@typescript-eslint/parser": "6.0.0",
@@ -10536,6 +10544,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -12208,7 +12217,8 @@
       "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -32438,10 +32448,6 @@
       "version": "2.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@netcracker/qubership-apihub-api-diff": "2.0.0",
-        "@netcracker/qubership-apihub-api-unifier": "2.0.0",
-        "@netcracker/qubership-apihub-graphapi": "1.0.8",
-        "@netcracker/qubership-apihub-json-crawl": "1.0.4",
         "postcss": "8.4.29",
         "react-markdown": "8.0.7",
         "react-use": "^17.6.0",
@@ -32449,8 +32455,6 @@
         "tailwindcss": "3.3.3"
       },
       "devDependencies": {
-        "@netcracker/qubership-apihub-compatibility-suites": "2.0.3",
-        "@netcracker/qubership-apihub-jest-chrome-in-docker-environment": "2.0.0",
         "@storybook/addon-essentials": "8.1.11",
         "@storybook/addon-interactions": "8.1.11",
         "@storybook/addon-links": "8.1.11",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,15 @@
     "lint:fix": "npm run lint:check -- --fix",
     "update-lock-file": "update-lock-file @netcracker"
   },
+  "dependencies": {
+    "@netcracker/qubership-apihub-api-diff": "2.0.0",
+    "@netcracker/qubership-apihub-api-unifier": "2.0.0",
+    "@netcracker/qubership-apihub-graphapi": "1.0.8",
+    "@netcracker/qubership-apihub-json-crawl": "1.0.4"
+  },
   "devDependencies": {
+    "@netcracker/qubership-apihub-compatibility-suites": "2.0.3",
+    "@netcracker/qubership-apihub-jest-chrome-in-docker-environment": "2.0.0",
     "@netcracker/qubership-apihub-npm-gitflow": "3.0.1",
     "@typescript-eslint/eslint-plugin": "6.0.0",
     "@typescript-eslint/parser": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "update-lock-file": "update-lock-file @netcracker"
   },
   "dependencies": {
-    "@netcracker/qubership-apihub-api-diff": "2.0.0",
+    "@netcracker/qubership-apihub-api-diff": "dev",
     "@netcracker/qubership-apihub-api-unifier": "2.0.0",
     "@netcracker/qubership-apihub-graphapi": "1.0.8",
     "@netcracker/qubership-apihub-json-crawl": "1.0.4"

--- a/packages/api-doc-viewer/package.json
+++ b/packages/api-doc-viewer/package.json
@@ -34,20 +34,14 @@
     "screenshot-test:regenerate-snapshots": "start-server-and-test development:local-server:static http://localhost:9009 screenshot-test:regenerate-snapshots:run",
     "screenshot-test:regenerate-snapshots:run": "jest --maxWorkers 4 --updateSnapshot -c .config/it/it-test-docker.jest.config.cjs"
   },
-  "dependencies": {
-    "@netcracker/qubership-apihub-api-diff": "2.0.0",
-    "@netcracker/qubership-apihub-api-unifier": "2.0.0",
-    "@netcracker/qubership-apihub-graphapi": "1.0.8",
-    "@netcracker/qubership-apihub-json-crawl": "1.0.4",
+  "dependencies": {    
     "postcss": "8.4.29",
     "react-markdown": "8.0.7",
     "react-use": "^17.6.0",
     "remark-gfm": "3.0.1",
     "tailwindcss": "3.3.3"
   },
-  "devDependencies": {
-    "@netcracker/qubership-apihub-compatibility-suites": "2.0.3",
-    "@netcracker/qubership-apihub-jest-chrome-in-docker-environment": "2.0.0",
+  "devDependencies": {    
     "@storybook/addon-essentials": "8.1.11",
     "@storybook/addon-interactions": "8.1.11",
     "@storybook/addon-links": "8.1.11",


### PR DESCRIPTION
If we try to rearrange dependencies exactly between packages- it does not work down the chain in apispec-view/ui.
Move @netcracker scoped dependencies which are used at least in one package to the core package.json Decided it is better to have them this way.