### PR TITLE
feat: render title and format in separate slots

### DIFF
--- a/packages/api-doc-viewer/src/builders/nodes.ts
+++ b/packages/api-doc-viewer/src/builders/nodes.ts
@@ -111,8 +111,9 @@ export function buildNodeTypeData(options: JsonNodeTypeDataOptions | GraphNodeTy
   const brokenRef = isRefNode(node) && node?.meta && 'brokenRef' in node.meta ? `${node.meta.brokenRef}` : undefined
   const type = brokenRef ? `$ref: ${brokenRef}` : $nodeValue?.type ?? UNKNOWN_TYPE_TEXT
   const nullable = nodeValue?.nullable
-  const entity = (nodeValue as IJsonSchemaStringType)?.format ?? $nodeValue?.title
+  const title = $nodeValue?.title
+  const qualifier = (nodeValue as IJsonSchemaStringType)?.format
   const combiner = isCombiner ? originalNode?.type : ''
 
-  return { brokenRef, type, nullable, entity, combiner }
+  return { brokenRef, type, nullable, title, qualifier, combiner }
 }

--- a/packages/api-doc-viewer/src/components/common/NodeType.tsx
+++ b/packages/api-doc-viewer/src/components/common/NodeType.tsx
@@ -372,14 +372,10 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
     }
 
     // Entity (title + format qualifier) — rendered with per-part diff coloring:
-    // only the changed sub-part (title or format) is colorized; when BOTH change,
-    // the whole bracketed string is colorized.
-    const titleChanged = titleAdded || titleRemoved || titleReplaced
-    const formatChanged = formatAdded || formatRemoved || formatReplaced
-    const bothChangedIncluded =
-      titleChanged && diffTypeForTitleIncluded &&
-      formatChanged && diffTypeForFormatIncluded
-
+    // only the changed sub-part (title or format) is colorized. The triangular brackets
+    // (and separator) are colorized only when EVERY present part is itself changed — i.e.
+    // the whole bracketed string is the change (e.g. `string` <-> `string<date-time>`, or
+    // both parts changing at once). They stay neutral when an unchanged part is present.
     const titleInput: QualifierPartInput = {
       value: title,
       beforeValue: beforeValueOf($titleChange),
@@ -400,11 +396,9 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
     actualEntity = renderQualifierDiff({
       titleInput,
       formatInput,
-      bothChanged: bothChangedIncluded,
       isSideBySide: isSideBySideDiffsLayoutMode,
       isInline: isInlineDiffsLayoutMode,
       originSide,
-      changedSide,
       colorizing: contentChangesColorizing,
       strikethrough: contentChangesStrikethrough,
     })
@@ -531,52 +525,52 @@ function bracketize(inner: ReactNode[], wrapperCls: string): ReactNode | null {
 function renderQualifierDiff(params: {
   titleInput: QualifierPartInput
   formatInput: QualifierPartInput
-  bothChanged: boolean
   isSideBySide: boolean
   isInline: boolean
   originSide: boolean
-  changedSide: boolean
   colorizing: boolean
   strikethrough: boolean
 }): ReactNode | null {
   const {
-    titleInput, formatInput, bothChanged,
+    titleInput, formatInput,
     isSideBySide, isInline, originSide,
     colorizing, strikethrough,
   } = params
 
-  const titlePart = buildQualifierPart(titleInput, colorizing, strikethrough)
-  const formatPart = buildQualifierPart(formatInput, colorizing, strikethrough)
+  // Bracket styles, applied only when every present part is changed (computed as included,
+  // since that condition already implies the parts' changes are included).
+  const { removeCls, addCls } = partStyles(true, colorizing, strikethrough)
 
-  // styling for the bracket wrapper when BOTH parts changed (colorize the whole string)
-  const bothIncluded = titleInput.included && formatInput.included
-  const { removeCls, addCls } = partStyles(bothIncluded, colorizing, strikethrough)
+  const parts = [
+    { input: titleInput, part: buildQualifierPart(titleInput, colorizing, strikethrough) },
+    { input: formatInput, part: buildQualifierPart(formatInput, colorizing, strikethrough) },
+  ]
 
   if (isSideBySide) {
     if (originSide) {
-      const segments = joinNodes(
-        [titlePart.originNode, formatPart.originNode].filter(Boolean) as ReactNode[],
-        ', ',
-      )
-      return bracketize(segments, bothChanged ? removeCls : '')
+      // origin shows the BEFORE state: parts that are removed/replaced/unchanged
+      const present = parts.filter(({ part }) => part.originNode != null)
+      const allChanged = present.length > 0 &&
+        present.every(({ input }) => (input.removed || input.replaced) && input.included)
+      const segments = joinNodes(present.map(({ part }) => part.originNode) as ReactNode[], ', ')
+      return bracketize(segments, allChanged ? removeCls : '')
     }
-    // changed side
-    const segments = joinNodes(
-      [titlePart.changedNode, formatPart.changedNode].filter(Boolean) as ReactNode[],
-      ', ',
-    )
-    return bracketize(segments, bothChanged ? addCls : '')
+    // changed side shows the AFTER state: parts that are added/replaced/unchanged
+    const present = parts.filter(({ part }) => part.changedNode != null)
+    const allChanged = present.length > 0 &&
+      present.every(({ input }) => (input.added || input.replaced) && input.included)
+    const segments = joinNodes(present.map(({ part }) => part.changedNode) as ReactNode[], ', ')
+    return bracketize(segments, allChanged ? addCls : '')
   }
 
   if (isInline) {
-    const partNodes: ReactNode[] = []
-    if (titlePart.inlineSeq.length) {
-      partNodes.push(joinInlineFragments(titlePart.inlineSeq))
-    }
-    if (formatPart.inlineSeq.length) {
-      partNodes.push(joinInlineFragments(formatPart.inlineSeq))
-    }
-    return bracketize(joinNodes(partNodes, ', '), '')
+    const present = parts.filter(({ part }) => part.inlineSeq.length > 0)
+    // brackets get a single color only when all present parts move in one direction
+    const allAdded = present.length > 0 && present.every(({ input }) => input.added && input.included)
+    const allRemoved = present.length > 0 && present.every(({ input }) => input.removed && input.included)
+    const bracketCls = allAdded ? addCls : allRemoved ? removeCls : ''
+    const partNodes = present.map(({ part }) => joinInlineFragments(part.inlineSeq))
+    return bracketize(joinNodes(partNodes, ', '), bracketCls)
   }
 
   return null

--- a/packages/api-doc-viewer/src/components/common/NodeType.tsx
+++ b/packages/api-doc-viewer/src/components/common/NodeType.tsx
@@ -371,149 +371,43 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
       }
     }
 
-    // Entity
-    const entityRemoved = formatRemoved || titleRemoved
-    const entityAdded = formatAdded || titleAdded
-    const entityReplaced = formatReplaced || titleReplaced
+    // Entity (title + format qualifier) — rendered with per-part diff coloring:
+    // only the changed sub-part (title or format) is colorized; when BOTH change,
+    // the whole bracketed string is colorized.
+    const titleChanged = titleAdded || titleRemoved || titleReplaced
+    const formatChanged = formatAdded || formatRemoved || formatReplaced
+    const bothChangedIncluded =
+      titleChanged && diffTypeForTitleIncluded &&
+      formatChanged && diffTypeForFormatIncluded
 
-    const diffTypeForEntityIncluded = diffTypeForFormatIncluded || diffTypeForTitleIncluded
-
-    if (isSideBySideDiffsLayoutMode) {
-      let diffStyles: unknown = null
-      if (entityRemoved) {
-        if (originSide) {
-          diffStyles = classes(
-            getIf(
-              diffTypeForEntityIncluded && contentChangesStrikethrough,
-              DEFAULT_STRIKETHROUGH_VALUE_CLASS
-            ),
-            getIf(
-              diffTypeForEntityIncluded && contentChangesColorizing,
-              INLINE_CONTENT_DIFF_COLOR_SCHEMAS[DiffAction.remove]
-            )
-          )
-          actualEntity =
-            <div className={`inline ${diffStyles}`}>
-              {wrappedEntity}
-            </div>
-        }
-        if (changedSide) {
-          actualEntity = null
-        }
-      }
-      if (entityAdded) {
-        if (originSide) {
-          actualEntity = null
-        }
-        if (changedSide) {
-          diffStyles = getIf(
-            diffTypeForEntityIncluded && contentChangesColorizing,
-            INLINE_CONTENT_DIFF_COLOR_SCHEMAS[DiffAction.add]
-          )
-          actualEntity =
-            <div className={`inline ${diffStyles}`}>
-              {wrappedEntity}
-            </div>
-        }
-      }
-      if (entityReplaced) {
-        if (originSide) {
-          diffStyles = classes(
-            getIf(
-              diffTypeForEntityIncluded && contentChangesStrikethrough,
-              DEFAULT_STRIKETHROUGH_VALUE_CLASS
-            ),
-            getIf(
-              diffTypeForEntityIncluded && contentChangesColorizing,
-              INLINE_CONTENT_DIFF_COLOR_SCHEMAS[DiffAction.remove]
-            )
-          )
-          const beforeQualifier =
-            diffReplace($formatChange)
-              ? $formatChange.beforeValue as string
-              : qualifier
-          const beforeTitle =
-            diffReplace($titleChange)
-              ? $titleChange.beforeValue as string
-              : title
-          actualEntity =
-            <div className={`inline ${diffStyles}`}>
-              {wrapAsEntity(buildEntityString(beforeTitle, beforeQualifier))}
-            </div>
-        }
-        if (changedSide) {
-          diffStyles = getIf(
-            diffTypeForEntityIncluded && contentChangesColorizing,
-            INLINE_CONTENT_DIFF_COLOR_SCHEMAS[DiffAction.add]
-          )
-          actualEntity =
-            <div className={`inline ${diffStyles}`}>
-              {wrappedEntity}
-            </div>
-        }
-      }
+    const titleInput: QualifierPartInput = {
+      value: title,
+      beforeValue: beforeValueOf($titleChange),
+      added: titleAdded,
+      removed: titleRemoved,
+      replaced: titleReplaced,
+      included: diffTypeForTitleIncluded,
+    }
+    const formatInput: QualifierPartInput = {
+      value: qualifier,
+      beforeValue: beforeValueOf($formatChange),
+      added: formatAdded,
+      removed: formatRemoved,
+      replaced: formatReplaced,
+      included: diffTypeForFormatIncluded,
     }
 
-    if (isInlineDiffsLayoutMode) {
-      if (entityRemoved) {
-        const diffStylesBefore = classes(
-          getIf(
-            diffTypeForEntityIncluded && contentChangesStrikethrough,
-            DEFAULT_STRIKETHROUGH_VALUE_CLASS
-          ),
-          getIf(
-            diffTypeForEntityIncluded && contentChangesColorizing,
-            INLINE_CONTENT_DIFF_COLOR_SCHEMAS[DiffAction.remove]
-          )
-        )
-        actualEntity =
-          <div className={`inline ${diffStylesBefore}`}>
-            {wrappedEntity}
-          </div>
-      }
-      if (entityAdded) {
-        const diffStylesAfter = getIf(
-          diffTypeForEntityIncluded && contentChangesColorizing,
-          INLINE_CONTENT_DIFF_COLOR_SCHEMAS[DiffAction.add]
-        )
-        actualEntity =
-          <div className={`inline ${diffStylesAfter}`}>
-            {wrappedEntity}
-          </div>
-      }
-      if (entityReplaced) {
-        const diffStylesBefore = classes(
-          getIf(
-            diffTypeForEntityIncluded && contentChangesStrikethrough,
-            DEFAULT_STRIKETHROUGH_VALUE_CLASS
-          ),
-          getIf(
-            diffTypeForEntityIncluded && contentChangesColorizing,
-            INLINE_CONTENT_DIFF_COLOR_SCHEMAS[DiffAction.remove]
-          )
-        )
-        const diffStylesAfter = getIf(
-          diffTypeForEntityIncluded && contentChangesColorizing,
-          INLINE_CONTENT_DIFF_COLOR_SCHEMAS[DiffAction.add]
-        )
-        const beforeQualifier =
-          diffReplace($formatChange)
-            ? $formatChange.beforeValue as string
-            : qualifier
-        const beforeTitle =
-          diffReplace($titleChange)
-            ? $titleChange.beforeValue as string
-            : title
-        actualEntity = <>
-          <div className={`inline ${diffStylesBefore}`}>
-            {wrapAsEntity(buildEntityString(beforeTitle, beforeQualifier))}
-          </div>
-          <div className={`inline ${diffStylesAfter}`}>
-            {wrappedEntity}
-          </div>
-        </>
-      }
-    }
+    actualEntity = renderQualifierDiff({
+      titleInput,
+      formatInput,
+      bothChanged: bothChangedIncluded,
+      isSideBySide: isSideBySideDiffsLayoutMode,
+      isInline: isInlineDiffsLayoutMode,
+      originSide,
+      changedSide,
+      colorizing: contentChangesColorizing,
+      strikethrough: contentChangesStrikethrough,
+    })
   }
 
   return (
@@ -532,6 +426,160 @@ function buildEntityString(title: string | undefined, qualifier: string | undefi
 
 function wrapAsEntity(entity: unknown): ReactNode {
   return <>{'<'}{entity}{'>'}</>
+}
+
+type QualifierPartInput = {
+  value: string | undefined        // after-state value of this part
+  beforeValue: string | undefined  // before-state value (for remove/replace)
+  added: boolean
+  removed: boolean
+  replaced: boolean
+  included: boolean                // is this part's change included by the active filters
+}
+
+type QualifierPart = {
+  originNode: ReactNode | null   // side-by-side origin side (before state)
+  changedNode: ReactNode | null  // side-by-side changed side (after state)
+  inlineSeq: ReactNode[]         // inline fragments in order (before, then after)
+}
+
+function beforeValueOf(change: unknown): string | undefined {
+  if (change && typeof change === 'object' && 'beforeValue' in change) {
+    const value = (change as { beforeValue?: unknown }).beforeValue
+    return typeof value === 'string' ? value : undefined
+  }
+  return undefined
+}
+
+function partStyles(
+  included: boolean,
+  colorizing: boolean,
+  strikethrough: boolean,
+): { removeCls: string; addCls: string } {
+  const removeCls = classes(
+    getIf(included && strikethrough, DEFAULT_STRIKETHROUGH_VALUE_CLASS),
+    getIf(included && colorizing, INLINE_CONTENT_DIFF_COLOR_SCHEMAS[DiffAction.remove]),
+  )
+  const addCls = getIf(included && colorizing, INLINE_CONTENT_DIFF_COLOR_SCHEMAS[DiffAction.add]) ?? ''
+  return { removeCls, addCls }
+}
+
+function styledText(text: string, cls: string): ReactNode {
+  return <span className={`inline ${cls}`.trimEnd()}>{text}</span>
+}
+
+function buildQualifierPart(
+  input: QualifierPartInput,
+  colorizing: boolean,
+  strikethrough: boolean,
+): QualifierPart {
+  const { value, beforeValue, added, removed, replaced, included } = input
+  const { removeCls, addCls } = partStyles(included, colorizing, strikethrough)
+
+  if (added) {
+    const after = value != null ? styledText(value, addCls) : null
+    return { originNode: null, changedNode: after, inlineSeq: after ? [after] : [] }
+  }
+  if (removed) {
+    const removedValue = beforeValue ?? value
+    const before = removedValue != null ? styledText(removedValue, removeCls) : null
+    return { originNode: before, changedNode: null, inlineSeq: before ? [before] : [] }
+  }
+  if (replaced) {
+    const before = beforeValue != null ? styledText(beforeValue, removeCls) : null
+    const after = value != null ? styledText(value, addCls) : null
+    return {
+      originNode: before,
+      changedNode: after,
+      inlineSeq: [before, after].filter(Boolean) as ReactNode[],
+    }
+  }
+  // unchanged
+  const neutral = value != null ? styledText(value, '') : null
+  return { originNode: neutral, changedNode: neutral, inlineSeq: neutral ? [neutral] : [] }
+}
+
+function joinNodes(nodes: ReactNode[], separator: string): ReactNode[] {
+  const out: ReactNode[] = []
+  nodes.forEach((node, index) => {
+    if (index > 0) {
+      out.push(<span key={`sep-${index}`} className="inline">{separator}</span>)
+    }
+    out.push(<span key={`seg-${index}`} className="inline">{node}</span>)
+  })
+  return out
+}
+
+function joinInlineFragments(fragments: ReactNode[]): ReactNode {
+  const out: ReactNode[] = []
+  fragments.forEach((fragment, index) => {
+    if (index > 0) {
+      out.push(<span key={`gap-${index}`} className="inline">{' '}</span>)
+    }
+    out.push(<span key={`frag-${index}`} className="inline">{fragment}</span>)
+  })
+  return <span className="inline">{out}</span>
+}
+
+function bracketize(inner: ReactNode[], wrapperCls: string): ReactNode | null {
+  if (inner.length === 0) {
+    return null
+  }
+  return <span className={`inline ${wrapperCls}`.trimEnd()}>{'<'}{inner}{'>'}</span>
+}
+
+function renderQualifierDiff(params: {
+  titleInput: QualifierPartInput
+  formatInput: QualifierPartInput
+  bothChanged: boolean
+  isSideBySide: boolean
+  isInline: boolean
+  originSide: boolean
+  changedSide: boolean
+  colorizing: boolean
+  strikethrough: boolean
+}): ReactNode | null {
+  const {
+    titleInput, formatInput, bothChanged,
+    isSideBySide, isInline, originSide,
+    colorizing, strikethrough,
+  } = params
+
+  const titlePart = buildQualifierPart(titleInput, colorizing, strikethrough)
+  const formatPart = buildQualifierPart(formatInput, colorizing, strikethrough)
+
+  // styling for the bracket wrapper when BOTH parts changed (colorize the whole string)
+  const bothIncluded = titleInput.included && formatInput.included
+  const { removeCls, addCls } = partStyles(bothIncluded, colorizing, strikethrough)
+
+  if (isSideBySide) {
+    if (originSide) {
+      const segments = joinNodes(
+        [titlePart.originNode, formatPart.originNode].filter(Boolean) as ReactNode[],
+        ', ',
+      )
+      return bracketize(segments, bothChanged ? removeCls : '')
+    }
+    // changed side
+    const segments = joinNodes(
+      [titlePart.changedNode, formatPart.changedNode].filter(Boolean) as ReactNode[],
+      ', ',
+    )
+    return bracketize(segments, bothChanged ? addCls : '')
+  }
+
+  if (isInline) {
+    const partNodes: ReactNode[] = []
+    if (titlePart.inlineSeq.length) {
+      partNodes.push(joinInlineFragments(titlePart.inlineSeq))
+    }
+    if (formatPart.inlineSeq.length) {
+      partNodes.push(joinInlineFragments(formatPart.inlineSeq))
+    }
+    return bracketize(joinNodes(partNodes, ', '), '')
+  }
+
+  return null
 }
 
 function getIf<T>(condition: boolean, value: T | undefined): T | null {

--- a/packages/api-doc-viewer/src/components/common/NodeType.tsx
+++ b/packages/api-doc-viewer/src/components/common/NodeType.tsx
@@ -131,9 +131,10 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
 
   let actualType: string | ReactNode = type
   let actualNullable: string | ReactNode = resolvedNullableText
-  // Rendered as `<type>[(<format>)][<<title>>]`, e.g. `string(date-time)<MyTitle>`:
-  // format is a parenthesized suffix, title an angle-bracketed suffix after it.
-  let actualFormat: ReactNode | null = hasText(qualifier) ? `(${qualifier})` : null
+  // Rendered as `<type>[(<qualifier>)][<<title>>]`, e.g. `string(date-time)<MyTitle>`:
+  // the qualifier (for a JSON type, its `format`) is a parenthesized suffix,
+  // title an angle-bracketed suffix after it.
+  let actualQualifier: ReactNode | null = hasText(qualifier) ? `(${qualifier})` : null
   let actualTitle: ReactNode | null = hasText(title) ? `<${title}>` : null
   if (!isDocumentLayoutMode) {
     // Node Type
@@ -373,8 +374,9 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
       }
     }
 
-    // Title prefix (`<title>: `) and format suffix (`(<format>)`) are independent tokens,
+    // The qualifier (`(...)`) and title (`<...>`) are independent suffix tokens,
     // each colorized as a whole (including its decoration) by its own change.
+    // For a JSON type the qualifier slot is fed from the `format` keyword's change.
     const titleInput: QualifierPartInput = {
       value: title,
       beforeValue: beforeValueOf($titleChange),
@@ -383,7 +385,7 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
       replaced: titleReplaced,
       included: diffTypeForTitleIncluded,
     }
-    const formatInput: QualifierPartInput = {
+    const qualifierInput: QualifierPartInput = {
       value: qualifier,
       beforeValue: beforeValueOf($formatChange),
       added: formatAdded,
@@ -401,8 +403,8 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
       colorizing: contentChangesColorizing,
       strikethrough: contentChangesStrikethrough,
     })
-    actualFormat = renderScalarDiff({
-      input: formatInput,
+    actualQualifier = renderScalarDiff({
+      input: qualifierInput,
       decorate: (text) => `(${text})`,
       isSideBySide: isSideBySideDiffsLayoutMode,
       isInline: isInlineDiffsLayoutMode,
@@ -415,7 +417,7 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
   return (
     <div className="inline-flex flex-row gap-1 items-center">
       {brokenRef && <WarningIcon />}
-      {actualType && <div className="inline">{actualType}{actualFormat}{actualTitle} {showNullable ? actualNullable : null}</div>}
+      {actualType && <div className="inline">{actualType}{actualQualifier}{actualTitle} {showNullable ? actualNullable : null}</div>}
       {combiner && <div className="inline">({combiner})</div>}
     </div>
   )
@@ -470,8 +472,8 @@ function joinInlineFragments(fragments: ReactNode[]): ReactNode {
   return <span className="inline">{out}</span>
 }
 
-// Renders a single scalar qualifier (title or format) as one token, decorating the value
-// (e.g. `<title>: ` or `(<format>)`) and colorizing the whole decorated token by its own change.
+// Renders a single decorated scalar token (the title `<...>` or the qualifier `(...)`),
+// colorizing the whole decorated token by its own change.
 function renderScalarDiff(params: {
   input: QualifierPartInput
   decorate: (text: string) => string

--- a/packages/api-doc-viewer/src/components/common/NodeType.tsx
+++ b/packages/api-doc-viewer/src/components/common/NodeType.tsx
@@ -45,7 +45,6 @@ export type NodeTypeProps = PropsWithoutChangesSummary<
 >
 
 const SEPARATOR = ' '
-const TITLE_TYPE_SEPARATOR = ': '
 
 /* FIXME 30.08.24 //
     There are a lot of places in NodeType when we use hardcoded action, not calculated from real data.
@@ -131,9 +130,10 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
 
   let actualType: string | ReactNode = type
   let actualNullable: string | ReactNode = resolvedNullableText
-  // Title is rendered as a prefix (`<title>: `), format as a parenthesized suffix (`(<format>)`).
-  let actualTitle: ReactNode | null = title != null ? `${title}${TITLE_TYPE_SEPARATOR}` : null
+  // Rendered as `<type>[(<format>)][<<title>>]`, e.g. `string(date-time)<MyTitle>`:
+  // format is a parenthesized suffix, title an angle-bracketed suffix after it.
   let actualFormat: ReactNode | null = qualifier != null ? `(${qualifier})` : null
+  let actualTitle: ReactNode | null = title != null ? `<${title}>` : null
   if (!isDocumentLayoutMode) {
     // Node Type
     if (isSideBySideDiffsLayoutMode) {
@@ -393,7 +393,7 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
 
     actualTitle = renderScalarDiff({
       input: titleInput,
-      decorate: (text) => `${text}${TITLE_TYPE_SEPARATOR}`,
+      decorate: (text) => `<${text}>`,
       isSideBySide: isSideBySideDiffsLayoutMode,
       isInline: isInlineDiffsLayoutMode,
       originSide,
@@ -414,7 +414,7 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
   return (
     <div className="inline-flex flex-row gap-1 items-center">
       {brokenRef && <WarningIcon />}
-      {actualType && <div className="inline">{actualTitle}{actualType}{actualFormat} {showNullable ? actualNullable : null}</div>}
+      {actualType && <div className="inline">{actualType}{actualFormat}{actualTitle} {showNullable ? actualNullable : null}</div>}
       {combiner && <div className="inline">({combiner})</div>}
     </div>
   )

--- a/packages/api-doc-viewer/src/components/common/NodeType.tsx
+++ b/packages/api-doc-viewer/src/components/common/NodeType.tsx
@@ -45,6 +45,7 @@ export type NodeTypeProps = PropsWithoutChangesSummary<
 >
 
 const SEPARATOR = ' '
+const TITLE_TYPE_SEPARATOR = ': '
 
 /* FIXME 30.08.24 //
     There are a lot of places in NodeType when we use hardcoded action, not calculated from real data.
@@ -72,8 +73,6 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
 
   const filters = useChangeSeverityFilters()
 
-  const entityString = buildEntityString(title, qualifier)
-  const wrappedEntity = entityString ? wrapAsEntity(entityString) : null
   const resolvedNullableText = nullable ? NULLABLE_TYPE_SUFFIX_TEXT : null
 
   const $typeChange = isDiff($changes?.type) ? $changes?.type : undefined
@@ -132,7 +131,9 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
 
   let actualType: string | ReactNode = type
   let actualNullable: string | ReactNode = resolvedNullableText
-  let actualEntity: ReactNode | null = wrappedEntity
+  // Title is rendered as a prefix (`<title>: `), format as a parenthesized suffix (`(<format>)`).
+  let actualTitle: ReactNode | null = title != null ? `${title}${TITLE_TYPE_SEPARATOR}` : null
+  let actualFormat: ReactNode | null = qualifier != null ? `(${qualifier})` : null
   if (!isDocumentLayoutMode) {
     // Node Type
     if (isSideBySideDiffsLayoutMode) {
@@ -371,11 +372,8 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
       }
     }
 
-    // Entity (title + format qualifier) — rendered with per-part diff coloring:
-    // only the changed sub-part (title or format) is colorized. The triangular brackets
-    // (and separator) are colorized only when EVERY present part is itself changed — i.e.
-    // the whole bracketed string is the change (e.g. `string` <-> `string<date-time>`, or
-    // both parts changing at once). They stay neutral when an unchanged part is present.
+    // Title prefix (`<title>: `) and format suffix (`(<format>)`) are independent tokens,
+    // each colorized as a whole (including its decoration) by its own change.
     const titleInput: QualifierPartInput = {
       value: title,
       beforeValue: beforeValueOf($titleChange),
@@ -393,9 +391,18 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
       included: diffTypeForFormatIncluded,
     }
 
-    actualEntity = renderQualifierDiff({
-      titleInput,
-      formatInput,
+    actualTitle = renderScalarDiff({
+      input: titleInput,
+      decorate: (text) => `${text}${TITLE_TYPE_SEPARATOR}`,
+      isSideBySide: isSideBySideDiffsLayoutMode,
+      isInline: isInlineDiffsLayoutMode,
+      originSide,
+      colorizing: contentChangesColorizing,
+      strikethrough: contentChangesStrikethrough,
+    })
+    actualFormat = renderScalarDiff({
+      input: formatInput,
+      decorate: (text) => `(${text})`,
       isSideBySide: isSideBySideDiffsLayoutMode,
       isInline: isInlineDiffsLayoutMode,
       originSide,
@@ -407,19 +414,10 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
   return (
     <div className="inline-flex flex-row gap-1 items-center">
       {brokenRef && <WarningIcon />}
-      {actualType && <div className="inline">{actualType}{actualEntity} {showNullable ? actualNullable : null}</div>}
+      {actualType && <div className="inline">{actualTitle}{actualType}{actualFormat} {showNullable ? actualNullable : null}</div>}
       {combiner && <div className="inline">({combiner})</div>}
     </div>
   )
-}
-
-function buildEntityString(title: string | undefined, qualifier: string | undefined): string | undefined {
-  const parts = [title, qualifier].filter(Boolean) as string[]
-  return parts.length > 0 ? parts.join(', ') : undefined
-}
-
-function wrapAsEntity(entity: unknown): ReactNode {
-  return <>{'<'}{entity}{'>'}</>
 }
 
 type QualifierPartInput = {
@@ -429,12 +427,6 @@ type QualifierPartInput = {
   removed: boolean
   replaced: boolean
   included: boolean                // is this part's change included by the active filters
-}
-
-type QualifierPart = {
-  originNode: ReactNode | null   // side-by-side origin side (before state)
-  changedNode: ReactNode | null  // side-by-side changed side (after state)
-  inlineSeq: ReactNode[]         // inline fragments in order (before, then after)
 }
 
 function beforeValueOf(change: unknown): string | undefined {
@@ -462,48 +454,6 @@ function styledText(text: string, cls: string): ReactNode {
   return <span className={`inline ${cls}`.trimEnd()}>{text}</span>
 }
 
-function buildQualifierPart(
-  input: QualifierPartInput,
-  colorizing: boolean,
-  strikethrough: boolean,
-): QualifierPart {
-  const { value, beforeValue, added, removed, replaced, included } = input
-  const { removeCls, addCls } = partStyles(included, colorizing, strikethrough)
-
-  if (added) {
-    const after = value != null ? styledText(value, addCls) : null
-    return { originNode: null, changedNode: after, inlineSeq: after ? [after] : [] }
-  }
-  if (removed) {
-    const removedValue = beforeValue ?? value
-    const before = removedValue != null ? styledText(removedValue, removeCls) : null
-    return { originNode: before, changedNode: null, inlineSeq: before ? [before] : [] }
-  }
-  if (replaced) {
-    const before = beforeValue != null ? styledText(beforeValue, removeCls) : null
-    const after = value != null ? styledText(value, addCls) : null
-    return {
-      originNode: before,
-      changedNode: after,
-      inlineSeq: [before, after].filter(Boolean) as ReactNode[],
-    }
-  }
-  // unchanged
-  const neutral = value != null ? styledText(value, '') : null
-  return { originNode: neutral, changedNode: neutral, inlineSeq: neutral ? [neutral] : [] }
-}
-
-function joinNodes(nodes: ReactNode[], separator: string): ReactNode[] {
-  const out: ReactNode[] = []
-  nodes.forEach((node, index) => {
-    if (index > 0) {
-      out.push(<span key={`sep-${index}`} className="inline">{separator}</span>)
-    }
-    out.push(<span key={`seg-${index}`} className="inline">{node}</span>)
-  })
-  return out
-}
-
 function joinInlineFragments(fragments: ReactNode[]): ReactNode {
   const out: ReactNode[] = []
   fragments.forEach((fragment, index) => {
@@ -515,62 +465,76 @@ function joinInlineFragments(fragments: ReactNode[]): ReactNode {
   return <span className="inline">{out}</span>
 }
 
-function bracketize(inner: ReactNode[], wrapperCls: string): ReactNode | null {
-  if (inner.length === 0) {
-    return null
-  }
-  return <span className={`inline ${wrapperCls}`.trimEnd()}>{'<'}{inner}{'>'}</span>
-}
-
-function renderQualifierDiff(params: {
-  titleInput: QualifierPartInput
-  formatInput: QualifierPartInput
+// Renders a single scalar qualifier (title or format) as one token, decorating the value
+// (e.g. `<title>: ` or `(<format>)`) and colorizing the whole decorated token by its own change.
+function renderScalarDiff(params: {
+  input: QualifierPartInput
+  decorate: (text: string) => string
   isSideBySide: boolean
   isInline: boolean
   originSide: boolean
   colorizing: boolean
   strikethrough: boolean
 }): ReactNode | null {
-  const {
-    titleInput, formatInput,
-    isSideBySide, isInline, originSide,
-    colorizing, strikethrough,
-  } = params
+  const { input, decorate, isSideBySide, isInline, originSide, colorizing, strikethrough } = params
+  const { value, beforeValue, added, removed, replaced, included } = input
+  const { removeCls, addCls } = partStyles(included, colorizing, strikethrough)
 
-  // Bracket styles, applied only when every present part is changed (computed as included,
-  // since that condition already implies the parts' changes are included).
-  const { removeCls, addCls } = partStyles(true, colorizing, strikethrough)
-
-  const parts = [
-    { input: titleInput, part: buildQualifierPart(titleInput, colorizing, strikethrough) },
-    { input: formatInput, part: buildQualifierPart(formatInput, colorizing, strikethrough) },
-  ]
+  const decorated = (text: string | undefined): string | null => (text != null ? decorate(text) : null)
+  const token = (text: string | null, cls: string): ReactNode | null => (text != null ? styledText(text, cls) : null)
 
   if (isSideBySide) {
     if (originSide) {
-      // origin shows the BEFORE state: parts that are removed/replaced/unchanged
-      const present = parts.filter(({ part }) => part.originNode != null)
-      const allChanged = present.length > 0 &&
-        present.every(({ input }) => (input.removed || input.replaced) && input.included)
-      const segments = joinNodes(present.map(({ part }) => part.originNode) as ReactNode[], ', ')
-      return bracketize(segments, allChanged ? removeCls : '')
+      // origin shows the BEFORE state
+      if (added) {
+        return null
+      }
+      if (removed) {
+        return token(decorated(beforeValue ?? value), removeCls)
+      }
+      if (replaced) {
+        return token(decorated(beforeValue), removeCls)
+      }
+      return token(decorated(value), '')
     }
-    // changed side shows the AFTER state: parts that are added/replaced/unchanged
-    const present = parts.filter(({ part }) => part.changedNode != null)
-    const allChanged = present.length > 0 &&
-      present.every(({ input }) => (input.added || input.replaced) && input.included)
-    const segments = joinNodes(present.map(({ part }) => part.changedNode) as ReactNode[], ', ')
-    return bracketize(segments, allChanged ? addCls : '')
+    // changed side shows the AFTER state
+    if (removed) {
+      return null
+    }
+    if (added || replaced) {
+      return token(decorated(value), addCls)
+    }
+    return token(decorated(value), '')
   }
 
   if (isInline) {
-    const present = parts.filter(({ part }) => part.inlineSeq.length > 0)
-    // brackets get a single color only when all present parts move in one direction
-    const allAdded = present.length > 0 && present.every(({ input }) => input.added && input.included)
-    const allRemoved = present.length > 0 && present.every(({ input }) => input.removed && input.included)
-    const bracketCls = allAdded ? addCls : allRemoved ? removeCls : ''
-    const partNodes = present.map(({ part }) => joinInlineFragments(part.inlineSeq))
-    return bracketize(joinNodes(partNodes, ', '), bracketCls)
+    const fragments: ReactNode[] = []
+    if (added) {
+      const after = token(decorated(value), addCls)
+      if (after) {
+        fragments.push(after)
+      }
+    } else if (removed) {
+      const before = token(decorated(beforeValue ?? value), removeCls)
+      if (before) {
+        fragments.push(before)
+      }
+    } else if (replaced) {
+      const before = token(decorated(beforeValue), removeCls)
+      const after = token(decorated(value), addCls)
+      if (before) {
+        fragments.push(before)
+      }
+      if (after) {
+        fragments.push(after)
+      }
+    } else {
+      const neutral = token(decorated(value), '')
+      if (neutral) {
+        fragments.push(neutral)
+      }
+    }
+    return fragments.length > 0 ? joinInlineFragments(fragments) : null
   }
 
   return null

--- a/packages/api-doc-viewer/src/components/common/NodeType.tsx
+++ b/packages/api-doc-viewer/src/components/common/NodeType.tsx
@@ -58,7 +58,8 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
     brokenRef,
     type,
     nullable,
-    entity,
+    title,
+    qualifier,
     combiner,
     // diffs
     layoutMode,
@@ -71,7 +72,8 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
 
   const filters = useChangeSeverityFilters()
 
-  const wrappedEntity = entity ? wrapAsEntity(entity) : null
+  const entityString = buildEntityString(title, qualifier)
+  const wrappedEntity = entityString ? wrapAsEntity(entityString) : null
   const resolvedNullableText = nullable ? NULLABLE_TYPE_SUFFIX_TEXT : null
 
   const $typeChange = isDiff($changes?.type) ? $changes?.type : undefined
@@ -426,17 +428,17 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
               INLINE_CONTENT_DIFF_COLOR_SCHEMAS[DiffAction.remove]
             )
           )
-          const replacedFormatValue =
+          const beforeQualifier =
             diffReplace($formatChange)
-              ? $formatChange.beforeValue
-              : undefined
-          const replacedTitleValue =
+              ? $formatChange.beforeValue as string
+              : qualifier
+          const beforeTitle =
             diffReplace($titleChange)
-              ? $titleChange.beforeValue
-              : undefined
+              ? $titleChange.beforeValue as string
+              : title
           actualEntity =
             <div className={`inline ${diffStyles}`}>
-              {wrapAsEntity(replacedFormatValue ?? replacedTitleValue)}
+              {wrapAsEntity(buildEntityString(beforeTitle, beforeQualifier))}
             </div>
         }
         if (changedSide) {
@@ -494,17 +496,17 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
           diffTypeForEntityIncluded && contentChangesColorizing,
           INLINE_CONTENT_DIFF_COLOR_SCHEMAS[DiffAction.add]
         )
-        const replacedFormatValue =
+        const beforeQualifier =
           diffReplace($formatChange)
-            ? $formatChange.beforeValue
-            : undefined
-        const replacedTitleValue =
+            ? $formatChange.beforeValue as string
+            : qualifier
+        const beforeTitle =
           diffReplace($titleChange)
-            ? $titleChange.beforeValue
-            : undefined
+            ? $titleChange.beforeValue as string
+            : title
         actualEntity = <>
           <div className={`inline ${diffStylesBefore}`}>
-            {wrapAsEntity(replacedFormatValue ?? replacedTitleValue)}
+            {wrapAsEntity(buildEntityString(beforeTitle, beforeQualifier))}
           </div>
           <div className={`inline ${diffStylesAfter}`}>
             {wrappedEntity}
@@ -516,11 +518,16 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
 
   return (
     <div className="inline-flex flex-row gap-1 items-center">
-      {brokenRef && <WarningIcon/>}
+      {brokenRef && <WarningIcon />}
       {actualType && <div className="inline">{actualType}{actualEntity} {showNullable ? actualNullable : null}</div>}
       {combiner && <div className="inline">({combiner})</div>}
     </div>
   )
+}
+
+function buildEntityString(title: string | undefined, qualifier: string | undefined): string | undefined {
+  const parts = [title, qualifier].filter(Boolean) as string[]
+  return parts.length > 0 ? parts.join(', ') : undefined
 }
 
 function wrapAsEntity(entity: unknown): ReactNode {

--- a/packages/api-doc-viewer/src/components/common/NodeType.tsx
+++ b/packages/api-doc-viewer/src/components/common/NodeType.tsx
@@ -15,7 +15,7 @@
  */
 
 import { isDiff } from '@netcracker/qubership-apihub-api-data-model'
-import { DiffAction } from '@netcracker/qubership-apihub-api-diff'
+import { Diff, DiffAction } from '@netcracker/qubership-apihub-api-diff'
 import type { FC, ReactNode } from 'react'
 import { DEFAULT_STRIKETHROUGH_VALUE_CLASS, INLINE_CONTENT_DIFF_COLOR_SCHEMAS } from '../../consts/changes'
 import { NULLABLE_TYPE_SUFFIX_TEXT, UNKNOWN_TYPE_TEXT } from '../../consts/types'
@@ -26,6 +26,7 @@ import { PropsWithoutChangesSummary } from '../../types/PropsWithoutChangesSumma
 import { LayoutSide } from '../../types/internal/LayoutSide'
 import { PropsWithChanges } from '../../types/internal/PropsWithChanges'
 import {
+  diffRemove,
   diffReplace,
   getLayoutModeFlags,
   getLayoutSideFlags,
@@ -132,8 +133,8 @@ export const NodeType: FC<NodeTypeProps> = (props) => {
   let actualNullable: string | ReactNode = resolvedNullableText
   // Rendered as `<type>[(<format>)][<<title>>]`, e.g. `string(date-time)<MyTitle>`:
   // format is a parenthesized suffix, title an angle-bracketed suffix after it.
-  let actualFormat: ReactNode | null = qualifier != null ? `(${qualifier})` : null
-  let actualTitle: ReactNode | null = title != null ? `<${title}>` : null
+  let actualFormat: ReactNode | null = hasText(qualifier) ? `(${qualifier})` : null
+  let actualTitle: ReactNode | null = hasText(title) ? `<${title}>` : null
   if (!isDocumentLayoutMode) {
     // Node Type
     if (isSideBySideDiffsLayoutMode) {
@@ -429,10 +430,14 @@ type QualifierPartInput = {
   included: boolean                // is this part's change included by the active filters
 }
 
-function beforeValueOf(change: unknown): string | undefined {
-  if (change && typeof change === 'object' && 'beforeValue' in change) {
-    const value = (change as { beforeValue?: unknown }).beforeValue
-    return typeof value === 'string' ? value : undefined
+// non-null and not blank (treats empty / whitespace-only as absent)
+function hasText(value: string | undefined): value is string {
+  return !!value && value.trim().length > 0
+}
+
+function beforeValueOf(change?: Diff): string | undefined {
+  if (diffRemove(change) || diffReplace(change)) {
+    return typeof change.beforeValue === 'string' ? change.beforeValue : undefined
   }
   return undefined
 }
@@ -480,8 +485,9 @@ function renderScalarDiff(params: {
   const { value, beforeValue, added, removed, replaced, included } = input
   const { removeCls, addCls } = partStyles(included, colorizing, strikethrough)
 
-  const decorated = (text: string | undefined): string | null => (text != null ? decorate(text) : null)
-  const token = (text: string | null, cls: string): ReactNode | null => (text != null ? styledText(text, cls) : null)
+  // Renders one decorated token, or null when the value is absent / blank.
+  const renderToken = (raw: string | undefined, cls: string): ReactNode | null =>
+    hasText(raw) ? styledText(decorate(raw), cls) : null
 
   if (isSideBySide) {
     if (originSide) {
@@ -490,38 +496,38 @@ function renderScalarDiff(params: {
         return null
       }
       if (removed) {
-        return token(decorated(beforeValue ?? value), removeCls)
+        return renderToken(beforeValue ?? value, removeCls)
       }
       if (replaced) {
-        return token(decorated(beforeValue), removeCls)
+        return renderToken(beforeValue, removeCls)
       }
-      return token(decorated(value), '')
+      return renderToken(value, '')
     }
     // changed side shows the AFTER state
     if (removed) {
       return null
     }
     if (added || replaced) {
-      return token(decorated(value), addCls)
+      return renderToken(value, addCls)
     }
-    return token(decorated(value), '')
+    return renderToken(value, '')
   }
 
   if (isInline) {
     const fragments: ReactNode[] = []
     if (added) {
-      const after = token(decorated(value), addCls)
+      const after = renderToken(value, addCls)
       if (after) {
         fragments.push(after)
       }
     } else if (removed) {
-      const before = token(decorated(beforeValue ?? value), removeCls)
+      const before = renderToken(beforeValue ?? value, removeCls)
       if (before) {
         fragments.push(before)
       }
     } else if (replaced) {
-      const before = token(decorated(beforeValue), removeCls)
-      const after = token(decorated(value), addCls)
+      const before = renderToken(beforeValue, removeCls)
+      const after = renderToken(value, addCls)
       if (before) {
         fragments.push(before)
       }
@@ -529,7 +535,7 @@ function renderScalarDiff(params: {
         fragments.push(after)
       }
     } else {
-      const neutral = token(decorated(value), '')
+      const neutral = renderToken(value, '')
       if (neutral) {
         fragments.push(neutral)
       }

--- a/packages/api-doc-viewer/src/types/NodeTypeData.ts
+++ b/packages/api-doc-viewer/src/types/NodeTypeData.ts
@@ -29,7 +29,8 @@ export type NodeTypeData = Partial<{
   brokenRef: string
   type: string
   nullable: boolean
-  entity: string
+  title: string
+  qualifier: string
   combiner: string
 }>
 


### PR DESCRIPTION
Changed rendering of type to `type(qualifier)<Title>` pattern (where qualifier is e.g. format for string in JSON schema, qualifier and title parts are both optional).
In this way qualifier and title each get it's own slot in rendering.